### PR TITLE
Use Alpine Linux for Docker Builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
-FROM golang:1.16-buster as builder
+FROM golang:1.16-alpine as builder
 
-RUN apt-get update && apt-get install -y \
-    libtagc0-dev upx-ucl libicu-dev
+RUN apk add --update taglib-dev libc-dev icu-dev upx make gcc git zlib-dev
 
 COPY . /src/euterpe
 WORKDIR /src/euterpe
@@ -10,9 +9,9 @@ RUN make release
 RUN mv euterpe /tmp/euterpe
 RUN /tmp/euterpe -config-gen && sed -i 's/localhost:9996/0.0.0.0:9996/' /root/.euterpe/config.json
 
-FROM debian:buster
+FROM alpine:latest
 
-RUN apt-get update && apt-get install -y libtagc0 libicu63
+RUN apk add --update taglib-dev libc-dev icu-dev
 
 COPY --from=builder /tmp/euterpe /usr/local/bin/euterpe
 COPY --from=builder /root/.euterpe/config.json /root/.euterpe/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-alpine as builder
+FROM golang:1.16-alpine3.13 as builder
 
 RUN apk add --update taglib-dev libc-dev icu-dev upx make gcc git zlib-dev
 
@@ -9,9 +9,9 @@ RUN make release
 RUN mv euterpe /tmp/euterpe
 RUN /tmp/euterpe -config-gen && sed -i 's/localhost:9996/0.0.0.0:9996/' /root/.euterpe/config.json
 
-FROM alpine:latest
+FROM alpine:3.13
 
-RUN apk add --update taglib-dev libc-dev icu-dev
+RUN apk add --update taglib libc-dev icu
 
 COPY --from=builder /tmp/euterpe /usr/local/bin/euterpe
 COPY --from=builder /root/.euterpe/config.json /root/.euterpe/config.json


### PR DESCRIPTION
Hello! Exploring euterpe and considering the possibility of adopting it for my personal music server. I thought I'd contribute a small change in return.

I suggest switching to alpine linux in the Dockerfile.

This results in:
- Smaller image sizes
- More secure application environment
- Only use packages required for build

Thanks so much!